### PR TITLE
Releasing v0.1.1.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "turbopelican"
-version = "0.1.0"
+version = "0.1.1"
 license = "AGPL-3.0-or-later"
 description = "An uber-quick tool to create a Pelican static-site and deploy it to GitHub Pages."
 readme = "README.md"


### PR DESCRIPTION
The previous commit incorrectly omitted the new version number from the `pyproject.toml` configuration.