### PR TITLE
Using non-relative URL for logo in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img width="400" alt="turbopelican logo" src="./assets/logo.svg"/></div>
+<div align="center"><img width="400" alt="turbopelican logo" src="https://raw.githubusercontent.com/clockback/turbopelican/refs/heads/main/assets/logo.svg"/></div>
 
 # turbopelican
 


### PR DESCRIPTION
This causes the markdown to fail to render the logo in certain contexts, such as on PyPI.