### PR TITLE
Fix `uv.lock`.

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "turbopelican"
-version = "0.1.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "langcodes" },


### PR DESCRIPTION
Incorrect `turbopelican` version number kept in `uv.lock`.